### PR TITLE
Add tables library so jupyterhub can load H5 files

### DIFF
--- a/jupyterlab/requirements.txt
+++ b/jupyterlab/requirements.txt
@@ -4,3 +4,4 @@ ipympl==0.2.1
 descartes==1.1.0
 ipyvolume==0.5.1 
 staticframe==0.3.0 
+tables==3.5.1 


### PR DESCRIPTION
I was able to pip install tables and test that I need it to load H5 files.